### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Create a Release
-        uses: elgohr/Github-Release-Action@main
+        uses: elgohr/Github-Release-Action@v4
       - name: Publish package
         run:
           mvn clean package -DattachMuleSources -Pgithub deploy


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore